### PR TITLE
88 [:bug:] 스케줄 리스트 조회 시 원본 스케줄 Id 미포함

### DIFF
--- a/src/main/java/com/jasik/momsnaggingapi/domain/schedule/Schedule.java
+++ b/src/main/java/com/jasik/momsnaggingapi/domain/schedule/Schedule.java
@@ -319,6 +319,8 @@ public class Schedule extends BaseTime {
 
         @Schema(description = "스케줄 ID", defaultValue = "22")
         private Long id;
+        @Schema(description = "원본 스케줄 ID", defaultValue = "2")
+        private Long originalId;
         @Schema(description = "n회 습관의 수행 목표 수", defaultValue = "0")
         private int goalCount;
         @Schema(description = "스케줄 이름", defaultValue = "술 마시기")


### PR DESCRIPTION
## 개요
- #88
- 스케줄 리스트 조회 시 원본 스케줄 Id 포함

## 작업 사항
- DTO 클래스에 originalId 컬럼 추가
